### PR TITLE
Add Study & Learn mode with Socratic guidance

### DIFF
--- a/frontend/components/ChatHeader.tsx
+++ b/frontend/components/ChatHeader.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react"
 import { Button } from "./ui/button"
-import { Pin } from 'lucide-react'
+import { Pin, GraduationCap } from 'lucide-react'
 import { SidebarTrigger, useSidebar } from "./ui/sidebar"
 import PinnedMessages from "./PinnedMessages"
+import { useStudyModeStore } from "@/frontend/stores/StudyModeStore"
 
 interface ChatHeaderProps {
   threadId: string
@@ -13,6 +14,8 @@ interface ChatHeaderProps {
 export function ChatHeader({ threadId }: ChatHeaderProps) {
   const { state } = useSidebar()
   const [showPinnedMessages, setShowPinnedMessages] = useState(false)
+  const studyModeEnabled = useStudyModeStore((state) => state.enabled)
+  const toggleStudyMode = useStudyModeStore((state) => state.toggle)
 
   return (
     <div className="fixed top-0 left-0 right-0 z-40 bg-background/80 backdrop-blur-sm border-b border-border/40">
@@ -23,6 +26,15 @@ export function ChatHeader({ threadId }: ChatHeaderProps) {
         </div>
         
         <div className="flex items-center gap-2">
+          <Button
+            onClick={toggleStudyMode}
+            variant={studyModeEnabled ? "default" : "outline"}
+            size="sm"
+            className="flex items-center gap-1"
+          >
+            <GraduationCap className="h-4 w-4" />
+            <span className="hidden sm:inline">Study</span>
+          </Button>
           <Button
             onClick={() => setShowPinnedMessages(!showPinnedMessages)}
             variant="outline"

--- a/frontend/hooks/useCustomResumableChat.ts
+++ b/frontend/hooks/useCustomResumableChat.ts
@@ -6,6 +6,7 @@ import { useAuth } from "@/frontend/components/AuthProvider"
 import { useAPIKeyStore } from "@/frontend/stores/APIKeyStore"
 import { useModelStore } from "@/frontend/stores/ModelStore"
 import { useWebSearchStore } from "@/frontend/stores/WebSearchStore"
+import { useStudyModeStore } from "@/frontend/stores/StudyModeStore"
 import { apiClient } from "@/lib/api-client"
 import { getActiveStreamsForThread, resumeStream } from "./resumable-streams-client"
 import type { UIMessage, Message, CreateMessage } from "ai"
@@ -35,6 +36,7 @@ export function useCustomResumableChat({
   const getKey = useAPIKeyStore((state) => state.getKey)
   const selectedModel = useModelStore((state) => state.selectedModel)
   const webSearchEnabled = useWebSearchStore((state) => state.enabled)
+  const studyModeEnabled = useStudyModeStore((state) => state.enabled)
 
   // Resume state
   const [isResuming, setIsResuming] = useState(false)
@@ -126,6 +128,7 @@ export function useCustomResumableChat({
           ...newBody,
           model: selectedModel,
           webSearchEnabled,
+          studyMode: studyModeEnabled,
           // Only include API key in body if it's valid
           ...(apiKey && typeof apiKey === 'string' && apiKey.trim().length > 0 && { apiKey }),
           // Preserve any existing data field (which may contain user preferences)

--- a/frontend/stores/StudyModeStore.ts
+++ b/frontend/stores/StudyModeStore.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+interface StudyModeState {
+  enabled: boolean
+  setEnabled: (enabled: boolean) => void
+  toggle: () => void
+}
+
+export const useStudyModeStore = create<StudyModeState>()(
+  persist(
+    (set, get) => ({
+      enabled: false,
+      setEnabled: (enabled: boolean) => set({ enabled }),
+      toggle: () => set({ enabled: !get().enabled }),
+    }),
+    {
+      name: "study-mode-settings",
+      version: 1,
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- add persistent Study Mode store and header toggle
- include Study Mode flag in chat requests and system prompt
- append Socratic instructions when Study Mode is active
- deduplicate custom instructions section in system prompt builder

## Testing
- `npm install --force` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f2f8c3cc83208fc0e93ec76b04bf