### PR TITLE
Fix mobile chat scrolling and keep input anchored

### DIFF
--- a/frontend/ChatLayout.tsx
+++ b/frontend/ChatLayout.tsx
@@ -267,7 +267,7 @@ export default function ChatLayout() {
 
   return (
     <SidebarProvider>
-      <div className="flex flex-1 relative">
+      <div className="flex flex-1 relative h-svh overflow-hidden">
         <ChatSidebar onRefreshData={sidebarRefreshRef} />
         <div className="flex-1 flex flex-col relative pl-2">
           {/* Sticky Header */}

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1069,7 +1069,7 @@ export default function Chat({ threadId, initialMessages, registerRef, onRefresh
   }
 
   return (
-    <div className="relative w-full">
+    <div className="relative flex flex-col h-full w-full overflow-hidden">
       <Button variant="outline" size="icon" onClick={toggleSidebar} className="fixed top-4 left-4 z-50 md:hidden">
         <ChevronDown className="h-4 w-4" />
       </Button>
@@ -1084,34 +1084,35 @@ export default function Chat({ threadId, initialMessages, registerRef, onRefresh
         </div>
       )}
 
-      <main className="flex flex-col w-full max-w-3xl pt-6 pb-36 sm:pt-10 sm:pb-48 mx-auto transition-all duration-300 ease-in-out px-4 sm:px-6 lg:px-8">
-
-        <RegenerationProvider
-          onMessageUpdate={(updatedMessage) => {
-            console.log("🔄 Updating message with new attempts:", updatedMessage.id, "Total attempts:", updatedMessage.attempts?.length)
-            setMessages((prevMessages) => {
-              return prevMessages.map(msg => 
-                msg.id === updatedMessage.id ? updatedMessage as UIMessage : msg
-              )
-            })
-          }}
-        >
-          <Messages
-            threadId={threadId}
-            messages={messages}
-            status={status}
-            setMessages={setMessages as any}
-            reload={reload}
-            error={error}
-            registerRef={registerRef || (() => {})}
-            stop={stop}
-            resumeComplete={resumeComplete}
-            resumedMessageId={resumedMessageId}
-            onPromptClick={handlePromptClick}
-          />
-        </RegenerationProvider>
-        <ChatInput threadId={threadId} input={input} status={status} append={append} setInput={setInput} stop={stop} onRefreshMessages={onRefreshMessages} />
+      <main className="flex-1 overflow-y-auto">
+        <div className="flex flex-col w-full max-w-3xl pt-6 pb-36 sm:pt-10 sm:pb-48 mx-auto transition-all duration-300 ease-in-out px-4 sm:px-6 lg:px-8">
+          <RegenerationProvider
+            onMessageUpdate={(updatedMessage) => {
+              console.log("🔄 Updating message with new attempts:", updatedMessage.id, "Total attempts:", updatedMessage.attempts?.length)
+              setMessages((prevMessages) => {
+                return prevMessages.map(msg =>
+                  msg.id === updatedMessage.id ? updatedMessage as UIMessage : msg
+                )
+              })
+            }}
+          >
+            <Messages
+              threadId={threadId}
+              messages={messages}
+              status={status}
+              setMessages={setMessages as any}
+              reload={reload}
+              error={error}
+              registerRef={registerRef || (() => {})}
+              stop={stop}
+              resumeComplete={resumeComplete}
+              resumedMessageId={resumedMessageId}
+              onPromptClick={handlePromptClick}
+            />
+          </RegenerationProvider>
+        </div>
       </main>
+      <ChatInput threadId={threadId} input={input} status={status} append={append} setInput={setInput} stop={stop} onRefreshMessages={onRefreshMessages} />
 
       {showScrollToBottom && (
         <div className={cn(


### PR DESCRIPTION
## Summary
- Prevent outer layout from exceeding viewport and hide extra scroll
- Restructure Chat component so only messages scroll while input stays fixed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; dependency installation conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68964dbcf4ac8320ae6d9f54cee641bf